### PR TITLE
Expand admin dashboard capabilities

### DIFF
--- a/admin/gerir_assinaturas.php
+++ b/admin/gerir_assinaturas.php
@@ -1,0 +1,154 @@
+<?php
+require_once __DIR__ . '/../sessao/session_handler.php';
+requireAdmin('../login.php');
+require_once __DIR__ . '/../db/db_connect.php';
+
+$pageTitle = 'Gerir Assinaturas';
+$mensagem = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['add_assinatura'])) {
+        $id_utilizador = filter_input(INPUT_POST, 'id_utilizador', FILTER_VALIDATE_INT);
+        $id_plano = filter_input(INPUT_POST, 'id_plano', FILTER_VALIDATE_INT);
+        if ($id_utilizador && $id_plano) {
+            $stmt = $pdo->prepare('INSERT INTO assinaturas_utilizador (id_utilizador, id_plano, data_inicio, estado_assinatura) VALUES (?, ?, NOW(), "ativa")');
+            $stmt->execute([$id_utilizador, $id_plano]);
+            $mensagem = 'Assinatura adicionada.';
+        } else {
+            $mensagem = 'Dados inválidos para nova assinatura.';
+        }
+    } elseif (isset($_POST['cancelar'])) {
+        $id = (int)$_POST['cancelar'];
+        $stmt = $pdo->prepare('UPDATE assinaturas_utilizador SET estado_assinatura="cancelada", data_fim=NOW() WHERE id_assinatura=?');
+        $stmt->execute([$id]);
+        $mensagem = 'Assinatura cancelada.';
+    } elseif (isset($_POST['ativar'])) {
+        $id = (int)$_POST['ativar'];
+        $stmt = $pdo->prepare('UPDATE assinaturas_utilizador SET estado_assinatura="ativa", data_fim=NULL WHERE id_assinatura=?');
+        $stmt->execute([$id]);
+        $mensagem = 'Assinatura ativada.';
+    } elseif (isset($_POST['del_assinatura'])) {
+        $id = (int)$_POST['del_assinatura'];
+        $stmt = $pdo->prepare('DELETE FROM assinaturas_utilizador WHERE id_assinatura=?');
+        $stmt->execute([$id]);
+        $mensagem = 'Assinatura removida.';
+    }
+}
+
+$assinaturas = [];
+$utilizadores = [];
+$planos = [];
+try {
+    $assinaturas = $pdo->query('SELECT a.id_assinatura, u.nome_completo, u.email, p.nome_plano, a.data_inicio, a.data_fim, a.data_proxima_cobranca, a.estado_assinatura FROM assinaturas_utilizador a JOIN utilizadores u ON a.id_utilizador=u.id_utilizador JOIN planos_assinatura p ON a.id_plano=p.id_plano ORDER BY a.id_assinatura DESC')->fetchAll();
+    $utilizadores = $pdo->query('SELECT id_utilizador, nome_completo FROM utilizadores ORDER BY nome_completo')->fetchAll();
+    $planos = $pdo->query('SELECT id_plano, nome_plano FROM planos_assinatura ORDER BY nome_plano')->fetchAll();
+} catch (PDOException $e) {
+    $mensagem = 'Erro ao carregar dados: ' . $e->getMessage();
+}
+
+$userName_for_header = $_SESSION['user_nome_completo'] ?? 'Admin';
+$avatarUrl_for_header = $_SESSION['user_avatar_url'] ?? '';
+if (!$avatarUrl_for_header) {
+    $initials_for_header = '';
+    $parts = explode(' ', trim($userName_for_header));
+    $initials_for_header .= strtoupper(substr($parts[0] ?? 'A',0,1));
+    if (count($parts)>1) $initials_for_header .= strtoupper(substr(end($parts),0,1));
+    if (strlen($initials_for_header)>2) $initials_for_header='AD';
+    $avatarUrl_for_header = 'https://ui-avatars.com/api/?name=' . urlencode($initials_for_header) . '&background=0D6EFD&color=fff&size=40&rounded=true&bold=true';
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($pageTitle); ?> - Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+</head>
+<body>
+<div class="main-wrapper d-flex">
+    <?php if (file_exists(__DIR__.'/sidebar.php')) require __DIR__.'/sidebar.php'; ?>
+    <div class="content-wrapper flex-grow-1" id="contentWrapper">
+        <?php if (file_exists(__DIR__.'/header.php')) require __DIR__.'/header.php'; ?>
+        <main class="admin-main-content p-4">
+            <div class="container-fluid">
+                <h1 class="h3 mb-4">Gerir Assinaturas</h1>
+                <?php if ($mensagem): ?>
+                    <div class="alert alert-info"><?php echo htmlspecialchars($mensagem); ?></div>
+                <?php endif; ?>
+                <form method="post" class="mb-4">
+                    <input type="hidden" name="add_assinatura" value="1">
+                    <div class="row g-2 align-items-end">
+                        <div class="col-md-4">
+                            <label class="form-label">Utilizador</label>
+                            <select name="id_utilizador" class="form-select" required>
+                                <option value="">Selecione</option>
+                                <?php foreach ($utilizadores as $u): ?>
+                                    <option value="<?php echo $u['id_utilizador']; ?>"><?php echo htmlspecialchars($u['nome_completo']); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Plano</label>
+                            <select name="id_plano" class="form-select" required>
+                                <option value="">Selecione</option>
+                                <?php foreach ($planos as $p): ?>
+                                    <option value="<?php echo $p['id_plano']; ?>"><?php echo htmlspecialchars($p['nome_plano']); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="col-md-4 text-end">
+                            <button class="btn btn-primary" type="submit">Adicionar</button>
+                        </div>
+                    </div>
+                </form>
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Utilizador</th>
+                                <th>Plano</th>
+                                <th>Estado</th>
+                                <th>Início</th>
+                                <th>Próxima Cobrança</th>
+                                <th>Fim</th>
+                                <th>Ações</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($assinaturas as $a): ?>
+                            <tr>
+                                <td><?php echo $a['id_assinatura']; ?></td>
+                                <td><?php echo htmlspecialchars($a['nome_completo']); ?><br><small><?php echo htmlspecialchars($a['email']); ?></small></td>
+                                <td><?php echo htmlspecialchars($a['nome_plano']); ?></td>
+                                <td><?php echo htmlspecialchars($a['estado_assinatura']); ?></td>
+                                <td><?php echo $a['data_inicio']; ?></td>
+                                <td><?php echo $a['data_proxima_cobranca'] ?? '-'; ?></td>
+                                <td><?php echo $a['data_fim'] ?? '-'; ?></td>
+                                <td>
+                                    <?php if ($a['estado_assinatura'] === 'ativa'): ?>
+                                        <form method="post" class="d-inline">
+                                            <button name="cancelar" value="<?php echo $a['id_assinatura']; ?>" class="btn btn-sm btn-warning">Cancelar</button>
+                                        </form>
+                                    <?php else: ?>
+                                        <form method="post" class="d-inline">
+                                            <button name="ativar" value="<?php echo $a['id_assinatura']; ?>" class="btn btn-sm btn-success">Ativar</button>
+                                        </form>
+                                    <?php endif; ?>
+                                    <form method="post" class="d-inline">
+                                        <button name="del_assinatura" value="<?php echo $a['id_assinatura']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Remover assinatura?')">Apagar</button>
+                                    </form>
+                                </td>
+                            </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/gerir_flashcards.php
+++ b/admin/gerir_flashcards.php
@@ -1,0 +1,127 @@
+<?php
+require_once __DIR__ . '/../sessao/session_handler.php';
+requireAdmin('../login.php');
+require_once __DIR__ . '/../db/db_connect.php';
+
+$pageTitle = 'Gerir Flashcards';
+$mensagem = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['add_flashcard'])) {
+        $pergunta = trim($_POST['pergunta'] ?? '');
+        $resposta = trim($_POST['resposta'] ?? '');
+        $id_assunto = filter_input(INPUT_POST, 'id_assunto', FILTER_VALIDATE_INT);
+        if ($pergunta && $resposta && $id_assunto) {
+            $stmt = $pdo->prepare('INSERT INTO flashcards (id_assunto, pergunta, resposta) VALUES (?, ?, ?)');
+            $stmt->execute([$id_assunto, $pergunta, $resposta]);
+            $mensagem = 'Flashcard adicionado.';
+        } else {
+            $mensagem = 'Dados inválidos.';
+        }
+    } elseif (isset($_POST['del_flashcard'])) {
+        $id = (int)$_POST['del_flashcard'];
+        $stmt = $pdo->prepare('DELETE FROM flashcards WHERE id_flashcard = ?');
+        $stmt->execute([$id]);
+        $mensagem = 'Flashcard removido.';
+    }
+}
+
+$flashcards = [];
+$assuntos = [];
+try {
+    $flashcards = $pdo->query('SELECT f.id_flashcard, f.pergunta, f.resposta, a.nome_assunto FROM flashcards f JOIN assuntos_podcast a ON f.id_assunto = a.id_assunto ORDER BY f.id_flashcard DESC')->fetchAll();
+    $assuntos = $pdo->query('SELECT id_assunto, nome_assunto FROM assuntos_podcast ORDER BY nome_assunto')->fetchAll();
+} catch (PDOException $e) {
+    $mensagem = 'Erro ao carregar dados: ' . $e->getMessage();
+}
+
+$userName_for_header = $_SESSION['user_nome_completo'] ?? 'Admin';
+$avatarUrl_for_header = $_SESSION['user_avatar_url'] ?? '';
+if (!$avatarUrl_for_header) {
+    $initials_for_header = '';
+    $parts = explode(' ', trim($userName_for_header));
+    $initials_for_header .= strtoupper(substr($parts[0] ?? 'A', 0, 1));
+    if (count($parts) > 1) $initials_for_header .= strtoupper(substr(end($parts), 0, 1));
+    if (strlen($initials_for_header) > 2) $initials_for_header = 'AD';
+    $avatarUrl_for_header = 'https://ui-avatars.com/api/?name=' . urlencode($initials_for_header) . '&background=0D6EFD&color=fff&size=40&rounded=true&bold=true';
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($pageTitle); ?> - Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+</head>
+<body>
+<div class="main-wrapper d-flex">
+    <?php if (file_exists(__DIR__.'/sidebar.php')) require __DIR__.'/sidebar.php'; ?>
+    <div class="content-wrapper flex-grow-1" id="contentWrapper">
+        <?php if (file_exists(__DIR__.'/header.php')) require __DIR__.'/header.php'; ?>
+        <main class="admin-main-content p-4">
+            <div class="container-fluid">
+                <h1 class="h3 mb-4">Gerir Flashcards</h1>
+                <?php if ($mensagem): ?>
+                    <div class="alert alert-info"><?php echo htmlspecialchars($mensagem); ?></div>
+                <?php endif; ?>
+                <form method="post" class="mb-4">
+                    <input type="hidden" name="add_flashcard" value="1">
+                    <div class="row g-2 align-items-end">
+                        <div class="col-md-3">
+                            <label class="form-label">Assunto</label>
+                            <select name="id_assunto" class="form-select" required>
+                                <option value="">Selecione</option>
+                                <?php foreach ($assuntos as $a): ?>
+                                    <option value="<?php echo $a['id_assunto']; ?>"><?php echo htmlspecialchars($a['nome_assunto']); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Pergunta</label>
+                            <input type="text" name="pergunta" class="form-control" required>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Resposta</label>
+                            <input type="text" name="resposta" class="form-control" required>
+                        </div>
+                        <div class="col-md-1 text-end">
+                            <button class="btn btn-primary" type="submit">Adicionar</button>
+                        </div>
+                    </div>
+                </form>
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Assunto</th>
+                                <th>Pergunta</th>
+                                <th>Resposta</th>
+                                <th>Ações</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($flashcards as $f): ?>
+                            <tr>
+                                <td><?php echo $f['id_flashcard']; ?></td>
+                                <td><?php echo htmlspecialchars($f['nome_assunto']); ?></td>
+                                <td><?php echo htmlspecialchars($f['pergunta']); ?></td>
+                                <td><?php echo htmlspecialchars($f['resposta']); ?></td>
+                                <td>
+                                    <form method="post" class="d-inline">
+                                        <button name="del_flashcard" value="<?php echo $f['id_flashcard']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Remover flashcard?')">Apagar</button>
+                                    </form>
+                                </td>
+                            </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/gerir_planos.php
+++ b/admin/gerir_planos.php
@@ -1,0 +1,127 @@
+<?php
+require_once __DIR__ . '/../sessao/session_handler.php';
+requireAdmin('../login.php');
+require_once __DIR__ . '/../db/db_connect.php';
+
+$pageTitle = 'Gerir Planos';
+$mensagem = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['add_plano'])) {
+        $nome = trim($_POST['nome_plano'] ?? '');
+        $preco_mensal = (float)($_POST['preco_mensal'] ?? 0);
+        $preco_anual = (float)($_POST['preco_anual'] ?? 0);
+        $ativo = isset($_POST['ativo']) ? 1 : 0;
+        if ($nome) {
+            $stmt = $pdo->prepare('INSERT INTO planos_assinatura (nome_plano, preco_mensal, preco_anual, ativo) VALUES (?, ?, ?, ?)');
+            $stmt->execute([$nome, $preco_mensal, $preco_anual, $ativo]);
+            $mensagem = 'Plano adicionado.';
+        } else {
+            $mensagem = 'Nome obrigatório.';
+        }
+    } elseif (isset($_POST['del_plano'])) {
+        $id = (int)$_POST['del_plano'];
+        $stmt = $pdo->prepare('DELETE FROM planos_assinatura WHERE id_plano = ?');
+        $stmt->execute([$id]);
+        $mensagem = 'Plano removido.';
+    }
+}
+
+$planos = [];
+try {
+    $planos = $pdo->query('SELECT id_plano, nome_plano, preco_mensal, preco_anual, ativo FROM planos_assinatura ORDER BY id_plano DESC')->fetchAll();
+} catch (PDOException $e) {
+    $mensagem = 'Erro ao carregar planos: ' . $e->getMessage();
+}
+
+$userName_for_header = $_SESSION['user_nome_completo'] ?? 'Admin';
+$avatarUrl_for_header = $_SESSION['user_avatar_url'] ?? '';
+if (!$avatarUrl_for_header) {
+    $initials_for_header = '';
+    $parts = explode(' ', trim($userName_for_header));
+    $initials_for_header .= strtoupper(substr($parts[0] ?? 'A', 0, 1));
+    if (count($parts) > 1) $initials_for_header .= strtoupper(substr(end($parts), 0, 1));
+    if (strlen($initials_for_header) > 2) $initials_for_header = 'AD';
+    $avatarUrl_for_header = 'https://ui-avatars.com/api/?name=' . urlencode($initials_for_header) . '&background=0D6EFD&color=fff&size=40&rounded=true&bold=true';
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($pageTitle); ?> - Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+</head>
+<body>
+<div class="main-wrapper d-flex">
+    <?php if (file_exists(__DIR__.'/sidebar.php')) require __DIR__.'/sidebar.php'; ?>
+    <div class="content-wrapper flex-grow-1" id="contentWrapper">
+        <?php if (file_exists(__DIR__.'/header.php')) require __DIR__.'/header.php'; ?>
+        <main class="admin-main-content p-4">
+            <div class="container-fluid">
+                <h1 class="h3 mb-4">Gerir Planos</h1>
+                <?php if ($mensagem): ?>
+                    <div class="alert alert-info"><?php echo htmlspecialchars($mensagem); ?></div>
+                <?php endif; ?>
+                <form method="post" class="mb-4">
+                    <input type="hidden" name="add_plano" value="1">
+                    <div class="row g-2 align-items-end">
+                        <div class="col-md-3">
+                            <label class="form-label">Nome</label>
+                            <input type="text" name="nome_plano" class="form-control" required>
+                        </div>
+                        <div class="col-md-2">
+                            <label class="form-label">Preço Mensal</label>
+                            <input type="number" step="0.01" name="preco_mensal" class="form-control" required>
+                        </div>
+                        <div class="col-md-2">
+                            <label class="form-label">Preço Anual</label>
+                            <input type="number" step="0.01" name="preco_anual" class="form-control" required>
+                        </div>
+                        <div class="col-md-2 form-check mt-4">
+                            <input type="checkbox" class="form-check-input" name="ativo" id="ativo">
+                            <label class="form-check-label" for="ativo">Ativo</label>
+                        </div>
+                        <div class="col-md-3 text-end">
+                            <button class="btn btn-primary" type="submit">Adicionar</button>
+                        </div>
+                    </div>
+                </form>
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Nome</th>
+                                <th>Mensal</th>
+                                <th>Anual</th>
+                                <th>Ativo</th>
+                                <th>Ações</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($planos as $p): ?>
+                            <tr>
+                                <td><?php echo $p['id_plano']; ?></td>
+                                <td><?php echo htmlspecialchars($p['nome_plano']); ?></td>
+                                <td>R$ <?php echo number_format($p['preco_mensal'],2,',','.'); ?></td>
+                                <td>R$ <?php echo number_format($p['preco_anual'],2,',','.'); ?></td>
+                                <td><?php echo $p['ativo'] ? 'Sim' : 'Não'; ?></td>
+                                <td>
+                                    <form method="post" class="d-inline">
+                                        <button name="del_plano" value="<?php echo $p['id_plano']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Remover plano?')">Apagar</button>
+                                    </form>
+                                </td>
+                            </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/gerir_quiz.php
+++ b/admin/gerir_quiz.php
@@ -1,0 +1,181 @@
+<?php
+require_once __DIR__ . '/../sessao/session_handler.php';
+requireAdmin('../login.php');
+require_once __DIR__ . '/../db/db_connect.php';
+
+$pageTitle = 'Gerir Quiz';
+$mensagem = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['add_pergunta'])) {
+        $texto = trim($_POST['texto_pergunta'] ?? '');
+        $id_assunto = filter_input(INPUT_POST, 'id_assunto', FILTER_VALIDATE_INT);
+        $explicacao = trim($_POST['explicacao'] ?? '');
+        if ($texto && $id_assunto) {
+            $stmt = $pdo->prepare('INSERT INTO quiz_perguntas (id_assunto, texto_pergunta, explicacao) VALUES (?, ?, ?)');
+            $stmt->execute([$id_assunto, $texto, $explicacao]);
+            $mensagem = 'Pergunta adicionada.';
+        } else {
+            $mensagem = 'Dados inválidos.';
+        }
+    } elseif (isset($_POST['del_pergunta'])) {
+        $id = (int)$_POST['del_pergunta'];
+        $stmt = $pdo->prepare('DELETE FROM quiz_perguntas WHERE id_pergunta = ?');
+        $stmt->execute([$id]);
+        $stmt = $pdo->prepare('DELETE FROM quiz_respostas WHERE id_pergunta = ?');
+        $stmt->execute([$id]);
+        $mensagem = 'Pergunta removida.';
+    } elseif (isset($_POST['add_resposta'])) {
+        $texto = trim($_POST['texto_resposta'] ?? '');
+        $id_pergunta = (int)$_POST['id_pergunta'];
+        $correta = isset($_POST['correta']) ? 1 : 0;
+        if ($texto && $id_pergunta) {
+            if ($correta) {
+                $stmt = $pdo->prepare('UPDATE quiz_respostas SET correta = 0 WHERE id_pergunta = ?');
+                $stmt->execute([$id_pergunta]);
+            }
+            $stmt = $pdo->prepare('INSERT INTO quiz_respostas (id_pergunta, texto_resposta, correta) VALUES (?, ?, ?)');
+            $stmt->execute([$id_pergunta, $texto, $correta]);
+            $mensagem = 'Resposta adicionada.';
+        }
+    } elseif (isset($_POST['del_resposta'])) {
+        $id = (int)$_POST['del_resposta'];
+        $stmt = $pdo->prepare('DELETE FROM quiz_respostas WHERE id_resposta = ?');
+        $stmt->execute([$id]);
+        $mensagem = 'Resposta removida.';
+    }
+}
+
+$perguntas = [];
+$assuntos = [];
+try {
+    $perguntas = $pdo->query('SELECT qp.id_pergunta, qp.texto_pergunta, qp.explicacao, a.nome_assunto FROM quiz_perguntas qp JOIN assuntos_podcast a ON qp.id_assunto = a.id_assunto ORDER BY qp.id_pergunta DESC')->fetchAll();
+    $assuntos = $pdo->query('SELECT id_assunto, nome_assunto FROM assuntos_podcast ORDER BY nome_assunto')->fetchAll();
+} catch (PDOException $e) {
+    $mensagem = 'Erro ao carregar dados: ' . $e->getMessage();
+}
+
+$answers = [];
+foreach ($perguntas as $p) {
+    $stmt = $pdo->prepare('SELECT id_resposta, texto_resposta, correta FROM quiz_respostas WHERE id_pergunta = ? ORDER BY id_resposta');
+    $stmt->execute([$p['id_pergunta']]);
+    $answers[$p['id_pergunta']] = $stmt->fetchAll();
+}
+
+$userName_for_header = $_SESSION['user_nome_completo'] ?? 'Admin';
+$avatarUrl_for_header = $_SESSION['user_avatar_url'] ?? '';
+if (!$avatarUrl_for_header) {
+    $initials_for_header = '';
+    $parts = explode(' ', trim($userName_for_header));
+    $initials_for_header .= strtoupper(substr($parts[0] ?? 'A', 0, 1));
+    if (count($parts) > 1) $initials_for_header .= strtoupper(substr(end($parts), 0, 1));
+    if (strlen($initials_for_header) > 2) $initials_for_header = 'AD';
+    $avatarUrl_for_header = 'https://ui-avatars.com/api/?name=' . urlencode($initials_for_header) . '&background=0D6EFD&color=fff&size=40&rounded=true&bold=true';
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($pageTitle); ?> - Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+</head>
+<body>
+<div class="main-wrapper d-flex">
+    <?php if (file_exists(__DIR__.'/sidebar.php')) require __DIR__.'/sidebar.php'; ?>
+    <div class="content-wrapper flex-grow-1" id="contentWrapper">
+        <?php if (file_exists(__DIR__.'/header.php')) require __DIR__.'/header.php'; ?>
+        <main class="admin-main-content p-4">
+            <div class="container-fluid">
+                <h1 class="h3 mb-4">Gerir Quiz</h1>
+                <?php if ($mensagem): ?>
+                    <div class="alert alert-info"><?php echo htmlspecialchars($mensagem); ?></div>
+                <?php endif; ?>
+                <form method="post" class="mb-4">
+                    <input type="hidden" name="add_pergunta" value="1">
+                    <div class="row g-2 align-items-end">
+                        <div class="col-md-3">
+                            <label class="form-label">Assunto</label>
+                            <select name="id_assunto" class="form-select" required>
+                                <option value="">Selecione</option>
+                                <?php foreach ($assuntos as $a): ?>
+                                    <option value="<?php echo $a['id_assunto']; ?>"><?php echo htmlspecialchars($a['nome_assunto']); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="col-md-5">
+                            <label class="form-label">Pergunta</label>
+                            <input type="text" name="texto_pergunta" class="form-control" required>
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Explicação</label>
+                            <input type="text" name="explicacao" class="form-control">
+                        </div>
+                        <div class="col-md-1 text-end">
+                            <button class="btn btn-primary" type="submit">Adicionar</button>
+                        </div>
+                    </div>
+                </form>
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Assunto</th>
+                                <th>Pergunta</th>
+                                <th>Respostas</th>
+                                <th>Ações</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($perguntas as $p): ?>
+                            <tr>
+                                <td><?php echo $p['id_pergunta']; ?></td>
+                                <td><?php echo htmlspecialchars($p['nome_assunto']); ?></td>
+                                <td><?php echo htmlspecialchars($p['texto_pergunta']); ?></td>
+                                <td>
+                                    <?php if (!empty($answers[$p['id_pergunta']])): ?>
+                                        <ul class="list-unstyled mb-0">
+                                            <?php foreach ($answers[$p['id_pergunta']] as $r): ?>
+                                                <li>
+                                                    <?php echo htmlspecialchars($r['texto_resposta']); ?>
+                                                    <?php if ($r['correta']): ?><strong>(correta)</strong><?php endif; ?>
+                                                    <form method="post" class="d-inline">
+                                                        <button name="del_resposta" value="<?php echo $r['id_resposta']; ?>" class="btn btn-sm btn-link text-danger">x</button>
+                                                    </form>
+                                                </li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    <?php else: ?>
+                                        Nenhuma resposta
+                                    <?php endif; ?>
+                                    <form method="post" class="mt-1">
+                                        <input type="hidden" name="add_resposta" value="1">
+                                        <input type="hidden" name="id_pergunta" value="<?php echo $p['id_pergunta']; ?>">
+                                        <div class="input-group input-group-sm">
+                                            <input type="text" name="texto_resposta" class="form-control" placeholder="Nova resposta" required>
+                                            <span class="input-group-text">
+                                                <input type="checkbox" name="correta" value="1"> correta
+                                            </span>
+                                            <button class="btn btn-outline-secondary" type="submit">Adicionar</button>
+                                        </div>
+                                    </form>
+                                </td>
+                                <td>
+                                    <form method="post" class="d-inline">
+                                        <button name="del_pergunta" value="<?php echo $p['id_pergunta']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Remover pergunta?')">Apagar</button>
+                                    </form>
+                                </td>
+                            </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/header.php
+++ b/admin/header.php
@@ -90,14 +90,14 @@ $userFirstName_for_header = explode(' ', $userName_for_header)[0];
                             <p class="mb-0 text-muted small text-truncate"><?php echo htmlspecialchars($userEmail_for_header); ?></p>
                         </div>
                     </li>
-                    <li><a class="dropdown-item py-2 d-flex align-items-center" href="../perfil_page_v1.html"> {/* Assuming perfil_page_v1.html exists */}
+                    <li><a class="dropdown-item py-2 d-flex align-items-center" href="../perfil_page_v1.html"><!-- Assuming perfil_page_v1.html exists -->
                         <i class="fas fa-user-circle fa-fw me-2 text-secondary"></i> Meu Perfil
                     </a></li>
                     <li><a class="dropdown-item py-2 d-flex align-items-center" href="../inicio.php">
                         <i class="fas fa-external-link-alt fa-fw me-2 text-secondary"></i> Ver Site Principal
                     </a></li>
                     <li><hr class="dropdown-divider my-1"></li>
-                    <li><a class="dropdown-item py-2 d-flex align-items-center text-danger" href="../logout_handler.php"> {/* Assuming logout_handler.php exists */}
+                    <li><a class="dropdown-item py-2 d-flex align-items-center text-danger" href="../logout_handler.php"><!-- Assuming logout_handler.php exists -->
                         <i class="fas fa-sign-out-alt fa-fw me-2"></i> Sair
                     </a></li>
                 </ul>

--- a/admin/index.php
+++ b/admin/index.php
@@ -32,6 +32,9 @@ $totalUtilizadores = 0;
 $novosUtilizadoresUltimos30Dias = 0;
 $totalPodcasts = 0;
 $totalAssinaturasAtivas = 0;
+$totalFlashcards = 0;
+$totalPerguntasQuiz = 0;
+$totalPlanos = 0;
 $erro_metricas = null;
 $labelsMeses = [];
 $dataNovosUtilizadoresMes = [];
@@ -55,6 +58,18 @@ try {
     $stmt = $pdo->query("SELECT COUNT(id_assinatura) FROM assinaturas_utilizador WHERE estado_assinatura = 'ativa'");
     $totalAssinaturasAtivas = $stmt->fetchColumn();
 
+    // Total de Flashcards
+    $stmt = $pdo->query("SELECT COUNT(id_flashcard) FROM flashcards");
+    $totalFlashcards = $stmt->fetchColumn();
+
+    // Total de Perguntas do Quiz
+    $stmt = $pdo->query("SELECT COUNT(id_pergunta) FROM quiz_perguntas");
+    $totalPerguntasQuiz = $stmt->fetchColumn();
+
+    // Total de Planos de Assinatura
+    $stmt = $pdo->query("SELECT COUNT(id_plano) FROM planos_assinatura");
+    $totalPlanos = $stmt->fetchColumn();
+
     // Dados para o gráfico de Novos Utilizadores (últimos 6 meses)
     for ($i = 5; $i >= 0; $i--) {
         $mesReferencia = date('Y-m-01', strtotime("-$i month"));
@@ -75,7 +90,7 @@ try {
 } catch (PDOException $e) {
     $erro_metricas = "Erro ao carregar métricas: " . $e->getMessage();
     error_log("Erro PDO no Dashboard: " . $e->getMessage());
-    $totalUtilizadores = $novosUtilizadoresUltimos30Dias = $totalPodcasts = $totalAssinaturasAtivas = 0; // Default to 0 on error
+    $totalUtilizadores = $novosUtilizadoresUltimos30Dias = $totalPodcasts = $totalAssinaturasAtivas = $totalFlashcards = $totalPerguntasQuiz = $totalPlanos = 0; // Default to 0 on error
     $labelsMeses = []; // Default to empty on error
     $dataNovosUtilizadoresMes = []; // Default to empty on error
     $dataFaturacaoMes = []; // Default to empty on error
@@ -299,6 +314,36 @@ try {
                 </section>
 
                 <section class="row g-4 mb-4">
+                    <div class="col-xl-4 col-md-6">
+                        <div class="metric-card text-center text-secondary">
+                            <div class="metric-icon bg-secondary-subtle text-secondary mx-auto">
+                                <i class="fas fa-clone"></i>
+                            </div>
+                            <div class="metric-value"><?php echo htmlspecialchars($totalFlashcards); ?></div>
+                            <div class="metric-label">Flashcards</div>
+                        </div>
+                    </div>
+                    <div class="col-xl-4 col-md-6">
+                        <div class="metric-card text-center text-danger">
+                            <div class="metric-icon bg-danger-subtle text-danger mx-auto">
+                                <i class="fas fa-question-circle"></i>
+                            </div>
+                            <div class="metric-value"><?php echo htmlspecialchars($totalPerguntasQuiz); ?></div>
+                            <div class="metric-label">Perguntas do Quiz</div>
+                        </div>
+                    </div>
+                    <div class="col-xl-4 col-md-6">
+                        <div class="metric-card text-center text-info">
+                            <div class="metric-icon bg-info-subtle text-info mx-auto">
+                                <i class="fas fa-dollar-sign"></i>
+                            </div>
+                            <div class="metric-value"><?php echo htmlspecialchars($totalPlanos); ?></div>
+                            <div class="metric-label">Planos Ativos</div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="row g-4 mb-4">
                     <div class="col-lg-7">
                         <div class="chart-card">
                             <h5 class="card-title mb-3 fw-semibold"><i class="fas fa-chart-line me-2 text-primary"></i>Novos Utilizadores (Últimos 6 Meses)</h5>
@@ -379,14 +424,58 @@ try {
                                 </div>
                             </a>
                         </div>
-                         <div class="col-sm-6 col-lg-4">
-                             <a href="gerir_oportunidades.php" class="quick-action-card d-flex align-items-center">
+                        <div class="col-sm-6 col-lg-4">
+                            <a href="gerir_oportunidades.php" class="quick-action-card d-flex align-items-center">
                                 <div class="quick-action-icon me-3">
                                     <i class="fas fa-bullhorn"></i>
                                 </div>
                                 <div>
                                     <h6 class="mb-0 fw-bold">Gerir Oportunidades</h6>
                                     <small class="text-muted">Cursos, vagas e eventos.</small>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="col-sm-6 col-lg-4">
+                            <a href="gerir_flashcards.php" class="quick-action-card d-flex align-items-center">
+                                <div class="quick-action-icon me-3">
+                                    <i class="fas fa-clone"></i>
+                                </div>
+                                <div>
+                                    <h6 class="mb-0 fw-bold">Gerir Flashcards</h6>
+                                    <small class="text-muted">Adicionar ou editar cartões.</small>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="col-sm-6 col-lg-4">
+                            <a href="gerir_quiz.php" class="quick-action-card d-flex align-items-center">
+                                <div class="quick-action-icon me-3">
+                                    <i class="fas fa-question-circle"></i>
+                                </div>
+                                <div>
+                                    <h6 class="mb-0 fw-bold">Gerir Quiz</h6>
+                                    <small class="text-muted">Perguntas e respostas.</small>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="col-sm-6 col-lg-4">
+                            <a href="gerir_planos.php" class="quick-action-card d-flex align-items-center">
+                                <div class="quick-action-icon me-3">
+                                    <i class="fas fa-dollar-sign"></i>
+                                </div>
+                                <div>
+                                    <h6 class="mb-0 fw-bold">Gerir Planos</h6>
+                                    <small class="text-muted">Planos de assinatura.</small>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="col-sm-6 col-lg-4">
+                            <a href="gerir_assinaturas.php" class="quick-action-card d-flex align-items-center">
+                                <div class="quick-action-icon me-3">
+                                    <i class="fas fa-file-contract"></i>
+                                </div>
+                                <div>
+                                    <h6 class="mb-0 fw-bold">Gerir Assinaturas</h6>
+                                    <small class="text-muted">Visualizar e controlar assinaturas.</small>
                                 </div>
                             </a>
                         </div>

--- a/admin/sidebar.php
+++ b/admin/sidebar.php
@@ -56,7 +56,31 @@ $nav_items = [
     'icon' => 'fas fa-newspaper', // Notícias icon (válido no Font Awesome)
     'text' => 'Notícias',
     'page_id' => 'gerir_noticias.php'
-]
+    ],
+    [
+        'href' => 'gerir_flashcards.php',
+        'icon' => 'fas fa-clone',
+        'text' => 'Flashcards',
+        'page_id' => 'gerir_flashcards.php'
+    ],
+    [
+        'href' => 'gerir_quiz.php',
+        'icon' => 'fas fa-question-circle',
+        'text' => 'Quiz',
+        'page_id' => 'gerir_quiz.php'
+    ],
+    [
+        'href' => 'gerir_planos.php',
+        'icon' => 'fas fa-dollar-sign',
+        'text' => 'Planos',
+        'page_id' => 'gerir_planos.php'
+    ],
+    [
+        'href' => 'gerir_assinaturas.php',
+        'icon' => 'fas fa-file-contract',
+        'text' => 'Assinaturas',
+        'page_id' => 'gerir_assinaturas.php'
+    ]
 
 ];
 


### PR DESCRIPTION
## Summary
- enhance admin dashboard with metrics for flashcards, quiz questions and plans
- add quick actions and navigation links for flashcards, quiz and plans
- create pages to manage flashcards, quiz questions & answers, and subscription plans
- fix header comment syntax
- add page to manage user subscriptions and link it in dashboard and sidebar

## Testing
- `php -v`
- `php -l admin/gerir_flashcards.php`
- `php -l admin/gerir_quiz.php`
- `php -l admin/gerir_planos.php`
- `php -l admin/gerir_assinaturas.php`
- `php -l admin/index.php`
- `php -l admin/sidebar.php`
- `php -l admin/header.php`


------
https://chatgpt.com/codex/tasks/task_e_684f77deaabc832794cc9ca516aba77f