### PR TITLE
Add gateway tracking for PIX payments

### DIFF
--- a/admin/gerir_assinaturas.php
+++ b/admin/gerir_assinaturas.php
@@ -39,7 +39,7 @@ $assinaturas = [];
 $utilizadores = [];
 $planos = [];
 try {
-    $assinaturas = $pdo->query('SELECT a.id_assinatura, u.nome_completo, u.email, p.nome_plano, a.data_inicio, a.data_fim, a.data_proxima_cobranca, a.estado_assinatura FROM assinaturas_utilizador a JOIN utilizadores u ON a.id_utilizador=u.id_utilizador JOIN planos_assinatura p ON a.id_plano=p.id_plano ORDER BY a.id_assinatura DESC')->fetchAll();
+    $assinaturas = $pdo->query('SELECT a.id_assinatura, u.nome_completo, u.email, p.nome_plano, a.data_inicio, a.data_fim, a.data_proxima_cobranca, a.estado_assinatura, a.gateway FROM assinaturas_utilizador a JOIN utilizadores u ON a.id_utilizador=u.id_utilizador JOIN planos_assinatura p ON a.id_plano=p.id_plano ORDER BY a.id_assinatura DESC')->fetchAll();
     $utilizadores = $pdo->query('SELECT id_utilizador, nome_completo FROM utilizadores ORDER BY nome_completo')->fetchAll();
     $planos = $pdo->query('SELECT id_plano, nome_plano FROM planos_assinatura ORDER BY nome_plano')->fetchAll();
 } catch (PDOException $e) {
@@ -110,6 +110,7 @@ if (!$avatarUrl_for_header) {
                                 <th>ID</th>
                                 <th>Utilizador</th>
                                 <th>Plano</th>
+                                <th>Gateway</th>
                                 <th>Estado</th>
                                 <th>Início</th>
                                 <th>Próxima Cobrança</th>
@@ -123,6 +124,7 @@ if (!$avatarUrl_for_header) {
                                 <td><?php echo $a['id_assinatura']; ?></td>
                                 <td><?php echo htmlspecialchars($a['nome_completo']); ?><br><small><?php echo htmlspecialchars($a['email']); ?></small></td>
                                 <td><?php echo htmlspecialchars($a['nome_plano']); ?></td>
+                                <td><?php echo htmlspecialchars($a['gateway'] ?? '-'); ?></td>
                                 <td><?php echo htmlspecialchars($a['estado_assinatura']); ?></td>
                                 <td><?php echo $a['data_inicio']; ?></td>
                                 <td><?php echo $a['data_proxima_cobranca'] ?? '-'; ?></td>

--- a/db/migrations/007_add_gateway_column.sql
+++ b/db/migrations/007_add_gateway_column.sql
@@ -1,0 +1,3 @@
+-- Add gateway column to assinaturas_utilizador
+ALTER TABLE assinaturas_utilizador
+    ADD COLUMN IF NOT EXISTS gateway VARCHAR(50) DEFAULT NULL AFTER id_transacao_gateway;

--- a/payments/gerar_pix_asaas.php
+++ b/payments/gerar_pix_asaas.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__ . '/../sessao/session_handler.php';
+require_once __DIR__ . '/../db/db_connect.php';
+
+requireLogin();
+
+header('Content-Type: application/json');
+
+// Este script é um placeholder simplificado para gerar cobranças PIX via Asaas
+$id_utilizador = $_SESSION['user_id'] ?? null;
+$id_plano = $_POST['planId'] ?? null;
+
+if (!$id_utilizador || !$id_plano) {
+    echo json_encode(['success' => false, 'message' => 'Dados incompletos.']);
+    exit;
+}
+
+$pdo->beginTransaction();
+try {
+    $stmt = $pdo->prepare("INSERT INTO assinaturas_utilizador (id_utilizador, id_plano, data_inicio, estado_assinatura, gateway) VALUES (?, ?, NOW(), 'pendente_pagamento', 'asaas')");
+    $stmt->execute([$id_utilizador, $id_plano]);
+    $id_assinatura = $pdo->lastInsertId();
+
+    if (!$id_assinatura) {
+        throw new Exception('Falha ao criar assinatura.');
+    }
+
+    // Aqui seria feita a chamada real à API Asaas para gerar a cobrança.
+    // Para fins de exemplo, usamos um txid fictício.
+    $txid = uniqid('asaas_');
+
+    $stmt = $pdo->prepare("UPDATE assinaturas_utilizador SET id_transacao_gateway = ?, gateway = 'asaas' WHERE id_assinatura = ?");
+    $stmt->execute([$txid, $id_assinatura]);
+
+    $pdo->commit();
+
+    echo json_encode(['success' => true, 'txid' => $txid, 'id_assinatura' => $id_assinatura]);
+} catch (Exception $e) {
+    $pdo->rollBack();
+    error_log('Erro gerar_pix_asaas: ' . $e->getMessage());
+    echo json_encode(['success' => false, 'message' => 'Erro ao gerar cobrança Asaas.']);
+}

--- a/payments/gerar_pix_efi.php
+++ b/payments/gerar_pix_efi.php
@@ -42,7 +42,7 @@ $pdo->beginTransaction();
 
 try {
     // 1. Criar registro de assinatura pendente
-    $stmt = $pdo->prepare("INSERT INTO assinaturas_utilizador (id_utilizador, id_plano, data_inicio, estado_assinatura) VALUES (?, ?, NOW(), 'pendente_pagamento')");
+    $stmt = $pdo->prepare("INSERT INTO assinaturas_utilizador (id_utilizador, id_plano, data_inicio, estado_assinatura, gateway) VALUES (?, ?, NOW(), 'pendente_pagamento', 'efi')");
     $stmt->execute([$id_utilizador, $id_plano]);
     $id_assinatura_criada = $pdo->lastInsertId();
 
@@ -73,7 +73,7 @@ try {
     $txid = $pixResponse['txid'];
 
     // 4. Atualizar assinatura pendente com o txid da Efí
-    $stmt = $pdo->prepare("UPDATE assinaturas_utilizador SET id_transacao_gateway = ? WHERE id_assinatura = ?");
+    $stmt = $pdo->prepare("UPDATE assinaturas_utilizador SET id_transacao_gateway = ?, gateway = 'efi' WHERE id_assinatura = ?");
     $stmt->execute([$txid, $id_assinatura_criada]);
 
     // 5. Obter dados do QR Code

--- a/payments/verificar_pix_asaas.php
+++ b/payments/verificar_pix_asaas.php
@@ -1,0 +1,51 @@
+<?php
+require_once __DIR__ . '/../sessao/session_handler.php';
+require_once __DIR__ . '/../db/db_connect.php';
+
+requireLogin();
+
+header('Content-Type: application/json');
+
+$txid = $_GET['txid'] ?? null;
+$id_utilizador = $_SESSION['user_id'] ?? null;
+
+if (!$txid || !$id_utilizador) {
+    echo json_encode(['success' => false, 'message' => 'Parâmetros ausentes.']);
+    exit;
+}
+
+try {
+    // Consulta simplificada; na prática, você verificaria o pagamento na API Asaas
+    $stmt = $pdo->prepare("SELECT a.*, p.preco_mensal, p.preco_anual FROM assinaturas_utilizador a JOIN planos_assinatura p ON a.id_plano = p.id_plano WHERE a.id_transacao_gateway = ? AND a.gateway = 'asaas' AND a.id_utilizador = ? AND a.estado_assinatura = 'pendente_pagamento'");
+    $stmt->execute([$txid, $id_utilizador]);
+    $assinatura = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($assinatura) {
+        // Aqui seria feita a confirmação real via API Asaas
+        $pdo->beginTransaction();
+        $interval = empty($assinatura['preco_anual']) || (float)$assinatura['preco_anual'] <= 0 ? 'P1M' : 'P1Y';
+        $data_inicio = new DateTime();
+        $data_proxima = (clone $data_inicio)->add(new DateInterval($interval));
+        $data_fim = clone $data_proxima;
+
+        $stmtUp = $pdo->prepare("UPDATE assinaturas_utilizador SET estado_assinatura = 'ativa', data_inicio = ?, data_fim = ?, data_proxima_cobranca = ? WHERE id_assinatura = ?");
+        $stmtUp->execute([
+            $data_inicio->format('Y-m-d H:i:s'),
+            $data_fim->format('Y-m-d H:i:s'),
+            $data_proxima->format('Y-m-d H:i:s'),
+            $assinatura['id_assinatura']
+        ]);
+
+        $stmtUser = $pdo->prepare("UPDATE utilizadores SET id_plano_assinatura_ativo = ? WHERE id_utilizador = ?");
+        $stmtUser->execute([$assinatura['id_plano'], $id_utilizador]);
+
+        $pdo->commit();
+        echo json_encode(['success' => true, 'isPaid' => true]);
+    } else {
+        echo json_encode(['success' => true, 'isPaid' => false]);
+    }
+} catch (Exception $e) {
+    $pdo->rollBack();
+    error_log('Erro verificar_pix_asaas: ' . $e->getMessage());
+    echo json_encode(['success' => false, 'message' => 'Erro ao verificar Pix Asaas.']);
+}

--- a/payments/verificar_pix_efi.php
+++ b/payments/verificar_pix_efi.php
@@ -33,7 +33,7 @@ try {
             $pdo->beginTransaction();
             try {
                 // Buscar a assinatura e o plano associado pelo txid
-                $stmtAssinatura = $pdo->prepare("SELECT a.*, p.preco_mensal, p.preco_anual FROM assinaturas_utilizador a JOIN planos_assinatura p ON a.id_plano = p.id_plano WHERE a.id_transacao_gateway = ? AND a.id_utilizador = ? AND a.estado_assinatura = 'pendente_pagamento'");
+                $stmtAssinatura = $pdo->prepare("SELECT a.*, p.preco_mensal, p.preco_anual FROM assinaturas_utilizador a JOIN planos_assinatura p ON a.id_plano = p.id_plano WHERE a.id_transacao_gateway = ? AND a.gateway = 'efi' AND a.id_utilizador = ? AND a.estado_assinatura = 'pendente_pagamento'");
                 $stmtAssinatura->execute([$txid, $id_utilizador]);
                 $assinatura = $stmtAssinatura->fetch(PDO::FETCH_ASSOC);
 

--- a/payments/webhook_efi.php
+++ b/payments/webhook_efi.php
@@ -119,7 +119,7 @@ try {
                  FROM assinaturas_utilizador a
                  JOIN planos_assinatura p ON a.id_plano = p.id_plano
                  JOIN utilizadores u ON a.id_utilizador = u.id_utilizador
-                 WHERE a.id_transacao_gateway = ? AND a.estado_assinatura = 'pendente_pagamento'"
+                WHERE a.id_transacao_gateway = ? AND a.gateway = 'efi' AND a.estado_assinatura = 'pendente_pagamento'"
             );
             $stmtAssinatura->execute([$txid]);
             $assinatura = $stmtAssinatura->fetch(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- add migration for new `gateway` column in assinaturas_utilizador
- record gateway in Pix generation scripts
- filter by gateway when validating payments
- display gateway information in admin panel
- provide placeholder Asaas integration scripts

## Testing
- `php` was not available so linting could not be run

------
https://chatgpt.com/codex/tasks/task_e_68579e123fac8327812cfc40aad86db0