### PR TITLE
Add Asaas webhook and card form

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Plataforma em PHP para gestão de podcasts e conteúdos para Terapia Ocupacional
 1. Copie o arquivo `db/config.php` e ajuste as variáveis de ambiente `DB_HOST`, `DB_NAME`, `DB_USER` e `DB_PASS` conforme sua base de dados.
 2. Para pagamentos, configure as variáveis `EFI_CLIENT_ID`, `EFI_CLIENT_SECRET`, `EFI_PIX_KEY`, `EFI_CERT_FILE` e `EFI_WEBHOOK_URL` utilizadas em `payments/config-efi.php`.
    Para o gateway Asaas defina `ASAAS_API_KEY`, `ASAAS_WEBHOOK_URL` e opcionalmente `ASAAS_SANDBOX` e `ASAAS_API_URL` em `payments/config-asaas.php`.
+   Configure também o endpoint do webhook apontando para `payments/webhook_asaas.php` e use essa URL em `ASAAS_WEBHOOK_URL`.
 3. Instale dependências do módulo de pagamentos:
 
 ```bash

--- a/payments/webhook_asaas.php
+++ b/payments/webhook_asaas.php
@@ -1,0 +1,67 @@
+<?php
+require_once __DIR__ . '/../db/db_connect.php';
+require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/includes/asaas-pix.php';
+require_once __DIR__ . '/includes/asaas-card.php';
+
+$logFile = __DIR__ . '/webhook_asaas.log';
+function log_msg($msg) {
+    global $logFile;
+    file_put_contents($logFile, '['.date('Y-m-d H:i:s')."] " . $msg . "\n", FILE_APPEND);
+}
+
+$payload = file_get_contents('php://input');
+log_msg('Payload: ' . $payload);
+$data = json_decode($payload, true);
+if (!$data) {
+    http_response_code(400);
+    echo json_encode(['error' => 'JSON invalido']);
+    exit;
+}
+$paymentId = $data['payment']['id'] ?? ($data['paymentId'] ?? ($data['id'] ?? null));
+if (!$paymentId) {
+    http_response_code(400);
+    echo json_encode(['error' => 'ID do pagamento nao encontrado']);
+    exit;
+}
+try {
+    $asaas = AsaasPix::getInstance();
+    $status = $asaas->checkPayment((string)$paymentId);
+    log_msg('Status API: ' . json_encode($status));
+    if ($status && isset($status['status']) && strtoupper($status['status']) === 'RECEIVED') {
+        $pdo->beginTransaction();
+        $stmt = $pdo->prepare("SELECT a.*, p.preco_mensal, p.preco_anual FROM assinaturas_utilizador a JOIN planos_assinatura p ON a.id_plano = p.id_plano WHERE a.id_transacao_gateway = ? AND a.estado_assinatura = 'pendente_pagamento'");
+        $stmt->execute([$paymentId]);
+        $assinatura = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($assinatura) {
+            $id_plano = $assinatura['id_plano'];
+            $id_user = $assinatura['id_utilizador'];
+            $data_inicio = new DateTime();
+            $intervalo = (!empty($assinatura['preco_anual']) && (float)$assinatura['preco_anual'] > 0) ? 'P1Y' : 'P1M';
+            $data_prox = clone $data_inicio;
+            $data_prox->add(new DateInterval($intervalo));
+            $data_fim = clone $data_prox;
+            $up = $pdo->prepare("UPDATE assinaturas_utilizador SET estado_assinatura='ativa', data_inicio=?, data_fim=?, data_proxima_cobranca=? WHERE id_assinatura=?");
+            $up->execute([
+                $data_inicio->format('Y-m-d H:i:s'),
+                $data_fim->format('Y-m-d H:i:s'),
+                $data_prox->format('Y-m-d H:i:s'),
+                $assinatura['id_assinatura']
+            ]);
+            $up2 = $pdo->prepare("UPDATE utilizadores SET id_plano_assinatura_ativo=? WHERE id_utilizador=?");
+            $up2->execute([$id_plano, $id_user]);
+            $pdo->commit();
+            log_msg('Assinatura ' . $assinatura['id_assinatura'] . ' ativada');
+        } else {
+            $pdo->rollBack();
+            log_msg('Assinatura pendente nao encontrada para ' . $paymentId);
+        }
+    }
+    http_response_code(200);
+    echo json_encode(['success' => true]);
+} catch (Exception $e) {
+    log_msg('Erro: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['error' => 'Erro interno']);
+}
+


### PR DESCRIPTION
## Summary
- add webhook handler for Asaas notifications
- support credit card form on plans page
- switch modal UI when paying with card
- document new webhook endpoint

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a4f628348327ae18b0c0fb990f16